### PR TITLE
Developer may choose between ' and " for divs attributes

### DIFF
--- a/lib/sinatra/flash/style.rb
+++ b/lib/sinatra/flash/style.rb
@@ -19,11 +19,11 @@ module Sinatra
       #   'flash_login' if you pass a key of  :login).  
       #
       # @return [String] Styled HTML if the flash contains messages, or an empty string if it's empty.
-      def styled_flash(key=:flash)
+      def styled_flash(key=:flash, attr_char = '\'')
         return "" if flash(key).empty?
         id = (key == :flash ? "flash" : "flash_#{key}")
-        messages = flash(key).collect {|message| "  <div class='flash #{message[0]}'>#{message[1]}</div>\n"}
-        "<div id='#{id}'>\n" + messages.join + "</div>"
+        messages = flash(key).collect {|message| "  <div class=#{attr_char}flash #{message[0]}#{attr_char}>#{message[1]}</div>\n"}
+        "<div id=#{attr_char}#{id}#{attr_char}>\n" + messages.join + "</div>"
       end
       
     end


### PR DESCRIPTION
I don't like mix ' with " in html attributes, but oirginal version of sinatra-flash always use '. I wrote some few characters for style.rb, and now it's possible to have " with flash divs attributes. Of course default behavior is still same as before.
