### PR TITLE
Update flash.rb

### DIFF
--- a/lib/sinatra/flash.rb
+++ b/lib/sinatra/flash.rb
@@ -12,7 +12,7 @@ module Sinatra
 
       # This callback rotates any flash structure we referenced, placing the 'next' hash into the session
       # for the next request.
-      app.after {@flash.each{|key, flash| session[key] = @flash[key].next} if @flash}
+      app.after {@flash.each{|key, flash| session[key] = @flash[key].next} if defined? @flash}
     end
 
   end


### PR DESCRIPTION
After run test on a sinatra application we found next error "sinatra-flash-0.3.0/lib/sinatra/flash.rb:15: warning: instance variable @flash not initialized"

We fix this issue adding a simple "defined?" method.

BR